### PR TITLE
Update foreign key constraint for Holes and Scores

### DIFF
--- a/priv/repo/migrations/20181202231534_add_delete_all_to_scores_for_round_id.exs
+++ b/priv/repo/migrations/20181202231534_add_delete_all_to_scores_for_round_id.exs
@@ -1,0 +1,10 @@
+defmodule Golf.Repo.Migrations.AddDeleteAllToScoresForRoundId do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE scores DROP CONSTRAINT scores_round_id_fkey"
+    alter table(:scores) do
+      modify :round_id, references(:rounds, on_delete: :delete_all)
+    end
+  end
+end

--- a/priv/repo/migrations/20181202232729_add_delete_all_to_holes_for_course_id.exs
+++ b/priv/repo/migrations/20181202232729_add_delete_all_to_holes_for_course_id.exs
@@ -1,0 +1,10 @@
+defmodule Golf.Repo.Migrations.AddDeleteAllToHolesForCourseId do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE holes DROP CONSTRAINT holes_course_id_fkey"
+    alter table(:holes) do
+      modify :course_id, references(:courses, on_delete: :delete_all)
+    end
+  end
+end

--- a/test/golf/courses/courses_test.exs
+++ b/test/golf/courses/courses_test.exs
@@ -4,7 +4,7 @@ defmodule Golf.CoursesTest do
   alias Golf.Courses
 
   describe "courses" do
-    alias Golf.Courses.Course
+    alias Golf.Courses.{Course, Hole}
 
     @valid_course_attrs %{"name" => "some name", "num_holes" => 9}
     @update_course_attrs %{"name" => "some updated name", "num_holes" => 18}
@@ -62,8 +62,11 @@ defmodule Golf.CoursesTest do
 
     test "delete_course/1 deletes the course" do
       course = insert(:course)
+      hole = insert(:hole, course: course)
+
       assert {:ok, %Course{}} = Courses.delete_course(course)
       assert_raise Ecto.NoResultsError, fn -> Courses.get_course!(course.id) end
+      assert_raise Ecto.NoResultsError, fn -> Golf.Repo.get!(Hole, hole.id) end
     end
 
     test "change_course/1 returns a course changeset" do

--- a/test/golf/scorecard/scorecard_test.exs
+++ b/test/golf/scorecard/scorecard_test.exs
@@ -4,7 +4,7 @@ defmodule Golf.ScorecardTest do
   alias Golf.Scorecard
 
   describe "rounds" do
-    alias Golf.Scorecard.Round
+    alias Golf.Scorecard.{Round, Score}
 
     @valid_attrs %{"started_on" => ~D[2010-04-17]}
     @update_attrs %{"started_on" => ~D[2011-05-18]}
@@ -52,7 +52,7 @@ defmodule Golf.ScorecardTest do
     test "update_round/2 with valid data updates the round" do
       course = insert(:course)
       hole = insert(:hole, course: course)
-      round = insert(:round)
+      round = insert(:round, course: course)
       insert(:score, hole: hole, round: round, num_strokes: nil)
 
       round = %{scores: [score]} = Scorecard.get_round!(round.id)
@@ -73,9 +73,14 @@ defmodule Golf.ScorecardTest do
     end
 
     test "delete_round/1 deletes the round" do
-      round = insert(:round)
+      course = insert(:course)
+      hole = insert(:hole, course: course)
+      round = insert(:round, course: course)
+      score = insert(:score, hole: hole, round: round, num_strokes: nil)
+
       assert {:ok, %Round{}} = Scorecard.delete_round(round)
       assert_raise Ecto.NoResultsError, fn -> Scorecard.get_round!(round.id) end
+      assert_raise Ecto.NoResultsError, fn -> Golf.Repo.get!(Score, score.id) end
     end
 
     test "change_round/1 returns a round changeset" do


### PR DESCRIPTION
* Update foreign key constraint for Holes and Scores
* When you delete a course, all holes should be deleted as well
* When you delete a round, all scores should be deleted as well
* Closes #18
* See #17