### PR TITLE
Filter rounds to current user in rounds query

### DIFF
--- a/lib/golf/scorecard/scorecard.ex
+++ b/lib/golf/scorecard/scorecard.ex
@@ -20,6 +20,17 @@ defmodule Golf.Scorecard do
   end
 
   @doc """
+  Returns the list of rounds for a golfer
+  """
+  def list_rounds(%{golfer_id: golfer_id}) do
+    Round
+    |> preload([:course, [scores: :hole]])
+    |> where(golfer_id: ^golfer_id)
+    |> Repo.all()
+    |> Enum.map(&Round.add_total_score_and_holes_to_play/1)
+  end
+
+  @doc """
   Gets a single round.
 
   Raises `Ecto.NoResultsError` if the Round does not exist.

--- a/lib/golf_web/resolvers/scorecard.ex
+++ b/lib/golf_web/resolvers/scorecard.ex
@@ -30,8 +30,12 @@ defmodule GolfWeb.Resolvers.Scorecard do
     {:ok, Scorecard.get_round!(id)}
   end
 
+  def list_rounds(_parent, _args, %{context: %{current_user: user}}) do
+    {:ok, Scorecard.list_rounds(%{golfer_id: user.id})}
+  end
+
   def list_rounds(_parent, _args, _resolution) do
-    {:ok, Scorecard.list_rounds()}
+    {:ok, []}
   end
 
   def update_score(_parent, %{id: id, input: params}, _resolution) do

--- a/test/golf/scorecard/scorecard_test.exs
+++ b/test/golf/scorecard/scorecard_test.exs
@@ -20,6 +20,19 @@ defmodule Golf.ScorecardTest do
       assert result.course.name == course.name
     end
 
+    test "list_rounds/1 returns all rounds for a golfer" do
+      golfer = insert(:user)
+      course = insert(:course)
+      round = insert(:round, course: course, golfer: golfer)
+
+      _other_round = insert(:round)
+
+      [result] = Scorecard.list_rounds(%{golfer_id: golfer.id})
+
+      assert result.id == round.id
+      assert result.course.name == course.name
+    end
+
     test "get_round!/1 returns the round with given id" do
       round = insert(:round)
       assert Scorecard.get_round!(round.id).id == round.id

--- a/test/golf_web/schema/mutation/create_round_test.exs
+++ b/test/golf_web/schema/mutation/create_round_test.exs
@@ -88,9 +88,4 @@ defmodule GolfWeb.Schema.Mutation.CreateRoundTest do
              ]
            }
   end
-
-  defp auth_user(conn, user) do
-    token = GolfWeb.Authentication.sign(%{id: user.id})
-    put_req_header(conn, "authorization", "Bearer #{token}")
-  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,6 +23,11 @@ defmodule GolfWeb.ConnCase do
 
       import Golf.Factory
 
+      defp auth_user(conn, user) do
+        token = GolfWeb.Authentication.sign(%{id: user.id})
+        put_req_header(conn, "authorization", "Bearer #{token}")
+      end
+
       # The default endpoint for testing
       @endpoint GolfWeb.Endpoint
     end


### PR DESCRIPTION
The current user should only see their rounds when they query rounds from the app